### PR TITLE
Remove RRComponentsKit dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,14 +13,13 @@ let package = Package(
       targets: ["RRColorKit"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/rudrankriyam/RRComponentsKit.git", from: "0.4.0")
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.
     // Targets can depend on other targets in this package, and on products in packages this package depends on.
     .target(
       name: "RRColorKit",
-      dependencies: ["RRComponentsKit"]),
+      dependencies: []),
     .testTarget(
       name: "RRColorKitTests",
       dependencies: ["RRColorKit"]),

--- a/Sources/RRColorKit/Views/RGBResultView.swift
+++ b/Sources/RRColorKit/Views/RGBResultView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import RRComponentsKit
 
 public struct RGBResultView: View {
     var color: RGBColorProtocol
@@ -16,7 +15,7 @@ public struct RGBResultView: View {
     }
     
     public var body: some View {
-        AStack(type: .color) {
+        VStack {
             ResultRow(RGBResultType.red, color.red)
             
             ResultRow(RGBResultType.green, color.green)
@@ -34,7 +33,7 @@ public struct HSBResultView: View {
     }
     
     public var body: some View {
-        AStack(type: .color) {
+        VStack {
             ResultRow(HSBResultType.hue, color.hue, 360)
             
             ResultRow(HSBResultType.saturation, color.saturation, 100)
@@ -54,7 +53,7 @@ public struct CMYKResultView: View {
     private let step = 100.0
     
     public var body: some View {
-        AStack(type: .color) {
+        VStack {
             ResultRow(CMYKResultType.cyan, color.cyan, step)
             
             ResultRow(CMYKResultType.magenta, color.magenta, step)


### PR DESCRIPTION
## Summary
- Removed RRComponentsKit package dependency as it was only used for `AStack` component
- Replaced `AStack` with native SwiftUI `VStack` in all result views
- Removed unnecessary import statements

## Changes
- Updated `Package.swift` to remove RRComponentsKit from dependencies
- Modified `RGBResultView.swift` to use native SwiftUI components instead of RRComponentsKit

## Test plan
- [x] Build the package successfully
- [x] Verify that RGBResultView, HSBResultView, and CMYKResultView still render correctly with VStack
- [x] Confirm no other files reference RRComponentsKit

🤖 Generated with [Claude Code](https://claude.ai/code)