### PR TITLE
[codex] Fix hex color strings with leading hash

### DIFF
--- a/Sources/HeatherKit/Extensions/String.swift
+++ b/Sources/HeatherKit/Extensions/String.swift
@@ -22,7 +22,8 @@ public extension String {
     /// ```
     var color: Color {
         var hexNumber: UInt64 = 0
-        _ = Scanner(string: self).scanHexInt64(&hexNumber)
+        let hexString = hasPrefix("#") ? String(dropFirst()) : self
+        _ = Scanner(string: hexString).scanHexInt64(&hexNumber)
 
         let red = Double((hexNumber & 0xFF0000) >> 16) / 255
         let green = Double((hexNumber & 0x00FF00) >> 8) / 255

--- a/Tests/HeatherKitTests/HeatherKitTests.swift
+++ b/Tests/HeatherKitTests/HeatherKitTests.swift
@@ -112,8 +112,8 @@ func testCMYKGradient() {
 
 @Test("String to Color conversion works for hex values")
 func testStringToColor() {
-    let redHex = "FF0000"
-    let _ = redHex.color // Successfully creates a Color
+    #expect("FF0000".color.hex == "FF0000")
+    #expect("#00FF00".color.hex == "00FF00")
 }
 
 @Test("String symbol extraction works")


### PR DESCRIPTION
## Summary

Fix `String.color` so six-digit hex colors with a leading `#` parse as their intended RGB value instead of silently producing black.

## Root Cause

`Scanner.scanHexInt64` was run against the full string. For input like `#00FF00`, scanning stopped at the leading `#`, left the parsed value as zero, and returned `Color(red: 0, green: 0, blue: 0)`.

## Changes

- Strip an optional leading `#` before scanning the hex value.
- Strengthen the string-to-color test so both bare and hash-prefixed hex strings round-trip through `Color.hex`.

## Validation

- Reproduced before the fix with `swift test --filter testStringToColor`, which returned `"000000"` for `"#00FF00".color.hex`.
- `swift test --filter testStringToColor`
- `swift test`
- `swift build`